### PR TITLE
Fix yes-no

### DIFF
--- a/syntaxes/paradox.tmLanguage.json
+++ b/syntaxes/paradox.tmLanguage.json
@@ -58,7 +58,7 @@
                 },
                 {
                     "name": "constant.language.paradox",
-                    "match": "(yes|no)+"
+                    "match": "\\b(yes|no)\\b"
                 },
                 {
                     "name": "constant.numeric.paradox",


### PR DESCRIPTION
Added word breaks so that "no" doesn't get highlighted in words like "nomad."

Example: 
![CW Tools syntax highlighting example](https://github.com/cwtools/paradox-syntax/assets/42080011/091b9101-80b6-4feb-8c39-7e53ee1a570d)
