### PR TITLE
Update constant.numeric.paradox

### DIFF
--- a/syntaxes/paradox.tmLanguage.json
+++ b/syntaxes/paradox.tmLanguage.json
@@ -63,7 +63,7 @@
                 {
                     "name": "constant.numeric.paradox",
                     "comment": "A RHS number, either integer or float, positive or negative",
-                    "match": "(?<![\\w\\.\\+\\-])[\\+\\-]?([0-9]+\\.?[0-9]*|(\\.[0-9]+))(?![\\w\\.\\+\\-])"
+                    "match": "(?<![\\w\\.\\+\\-])[\\+\\-]?(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))(?![\\w\\.\\+\\-])"
                 },
                 {
                     "name": "constant.rhs.paradox",

--- a/syntaxes/paradox.tmLanguage.json
+++ b/syntaxes/paradox.tmLanguage.json
@@ -63,7 +63,7 @@
                 {
                     "name": "constant.numeric.paradox",
                     "comment": "A RHS number, either integer or float, positive or negative",
-                    "match": "-?\\b(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))\\b"
+                    "match": "(?<![\\w\\.\\+\\-])[\\+\\-]?([0-9]+\\.?[0-9]*|(\\.[0-9]+))(?![\\w\\.\\+\\-])"
                 },
                 {
                     "name": "constant.rhs.paradox",


### PR DESCRIPTION
This update to the matching rule for `constant.numeric.paradox` highlights plus signs and avoids more general combinations of digits and dots.